### PR TITLE
Version 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "timey"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timey"
-version = "0.1.0"
+version = "0.2.0"
 description = "A simple command line tool for converting between timestamps and datetime strings"
 license = "MIT"
 authors = ["Peter Bryant <petermbryant@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -52,3 +52,31 @@ For a full list of formatting specifiers, see [here](https://docs.rs/chrono/0.4.
 -m, --millis # Use timestamps in millis rather than seconds
 -h, --help # Display help
 ```
+
+## Display Current Time
+
+_The `-c` flag for copying the result to the clipboard also works with these commands._
+
+### As a timestamp
+
+```bash
+$ timey now display
+1551908316
+```
+
+```bash
+$ timey now display -m
+1551908316000
+```
+
+### As a formatted date-time string
+
+```bash
+$ timey now format
+2019-03-06T21:38:30.265352+00:00
+```
+
+```bash
+$ timey now format -f '%Y-%m-%d'
+2019-03-06
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Timey
 
 [![Build Status](https://travis-ci.org/ptrbrynt/timey.svg?branch=develop)](https://travis-ci.org/ptrbrynt/timey)
+![Crates.io](https://img.shields.io/crates/v/timey.svg)
+![Crates.io](https://img.shields.io/crates/d/timey.svg)
+![Crates.io](https://img.shields.io/crates/l/timey.svg)
 
 Timey is a command-line application written in Rust which allows for quick and easy translation between timestamps and formatted date-times.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/ptrbrynt/timey.svg?branch=develop)](https://travis-ci.org/ptrbrynt/timey)
 ![Crates.io](https://img.shields.io/crates/v/timey.svg)
 ![Crates.io](https://img.shields.io/crates/d/timey.svg)
+![Libraries.io dependency status for GitHub repo](https://img.shields.io/librariesio/github/ptrbrynt/timey.svg)
 ![Crates.io](https://img.shields.io/crates/l/timey.svg)
 
 Timey is a command-line application written in Rust which allows for quick and easy translation between timestamps and formatted date-times.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,10 @@ pub fn run() -> Result<(), &'static str> {
 
     let subcommand_matches = match subcommand_matches {
         Some(value) => value,
-        None => return Err("Subcommand not present"),
+        None => {
+            println!("Please specify a subcommand, or type 'timey -h' for help");
+            return Ok(());
+        }
     };
 
     if subcommand == "parse" {


### PR DESCRIPTION
* Implements new `now` subcommand
* Replaces the unhelpful error message when no subcommand is specified; will now display help text